### PR TITLE
Added acl support for consumer groups in CheectahKafkaAuthorizer

### DIFF
--- a/src/main/java/com/trifork/cheetah/GroupAccess.java
+++ b/src/main/java/com/trifork/cheetah/GroupAccess.java
@@ -1,0 +1,16 @@
+package com.trifork.cheetah;
+
+import org.apache.kafka.common.acl.AclOperation;
+
+public class GroupAccess
+{
+    public final String pattern;
+
+    public GroupAccess(String pattern, String operation)
+    {
+        this.pattern = pattern;
+        this.operation = AclOperation.valueOf(operation.replace("-", "_").toUpperCase());
+    }
+
+    public final AclOperation operation;
+}


### PR DESCRIPTION
Added ACL support for consumer groups allowing things like "Kafka_Group_MyGroup_read"