### PR TITLE
Kafka now runs on 3.9.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka_2.13</artifactId>
-            <version>3.9.1</version>
+            <version>3.9.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
This PR was made because we are bumping Strimzi to 0.47.0 and after release has been made Kafka will be bumped to 3.9.1