### PR TITLE
Removes trivy temporarily

### DIFF
--- a/.github/workflows/trivy-pr.yml
+++ b/.github/workflows/trivy-pr.yml
@@ -1,7 +1,7 @@
 name: Docker Trivy Call
 
 on:
-  pull_request:
+  # pull_request:
 
 jobs:
   trivy-image-scan:

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,9 @@ RUN mvn dependency:go-offline -B
 COPY src ./src
 RUN mvn -B package
 
-FROM quay.io/strimzi/kafka:0.48.0-kafka-4.1.0
+FROM quay.io/strimzi/kafka:0.45.0-kafka-3.8.0
 
-LABEL version="strimzi-0.48.0-kafka-4.1.0-trifork-1.9.0"
+LABEL version="strimzi-0.45.0-kafka-3.8.0-trifork-1.8.0"
 
 USER root:root
 COPY --from=build /app/target/cheetah-kafka-authorizer*.jar /opt/kafka/libs/cheetah-kafka-authorizer.jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN mvn -B package
 
 FROM quay.io/strimzi/kafka:0.48.0-kafka-4.1.0
 
-LABEL version="strimzi-0.48.0-kafka-4.1.0-trifork-1.8.0"
+LABEL version="strimzi-0.48.0-kafka-4.1.0-trifork-1.9.0"
 
 USER root:root
 COPY --from=build /app/target/cheetah-kafka-authorizer*.jar /opt/kafka/libs/cheetah-kafka-authorizer.jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,9 @@ RUN mvn dependency:go-offline -B
 COPY src ./src
 RUN mvn -B package
 
-FROM quay.io/strimzi/kafka:0.45.0-kafka-3.8.0
+FROM quay.io/strimzi/kafka:0.48.0-kafka-4.1.0
 
-LABEL version="strimzi-0.45.0-kafka-3.8.0-trifork-1.8.0"
+LABEL version="strimzi-0.48.0-kafka-4.1.0-trifork-1.8.0"
 
 USER root:root
 COPY --from=build /app/target/cheetah-kafka-authorizer*.jar /opt/kafka/libs/cheetah-kafka-authorizer.jar


### PR DESCRIPTION
Critical Vulnerability in Trivys ecosystem

[GHSA-69fq-xp46-6x23](https://github.com/aquasecurity/trivy/security/advisories/GHSA-69fq-xp46-6x23)

https://www.docker.com/blog/trivy-supply-chain-compromise-what-docker-hub-users-should-know/